### PR TITLE
Switch to Hugo Modules + Add Papers

### DIFF
--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -9,7 +9,6 @@ Hi, I'm Zhong Zhang, a third year math PhD Student at the University of Chicago,
 
 I am generally interested in topology and geometry. I often think about algebraic varieties through a topological lens. Lately, my work has focused on mapping class groups, moduli spaces of curves, and monodromy. Outside of math, I enjoy cooking, rock climbing, and playing table tennis. 
 
+Below is a list of my most recent preprints and published papers. To see all of my papers, see [my research page](../research)
 
-
-
-
+{{< first5sections page="research/_index.md" n=5 >}}

--- a/content/research/_index.md
+++ b/content/research/_index.md
@@ -4,7 +4,7 @@ draft: false
 layout: single
 ---
 
-**Linear representations of the mapping class group of dimension at most 3g − 3**  
+### Linear representations of the mapping class group of dimension at most 3g − 3
 
 with Julian Kaufmann, [Nick Salter](https://nsalter.science.nd.edu/), [Xiyan Zhong](https://xiyan-zhong.github.io/)
 [arxiv](https://arxiv.org/abs/2507.11365) [pdf](mcgreps.pdf)  

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/zhongzhang-math/zhongzhang-math.github.io
+
+go 1.24.6
+
+require github.com/lukeorth/poison v0.0.0-20240905132908-07485e85f024 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/lukeorth/poison v0.0.0-20240905132908-07485e85f024 h1:wJgYgCnf0vPFzcLWOTroGM23eq3iONBhAKMyAPMvSz8=
+github.com/lukeorth/poison v0.0.0-20240905132908-07485e85f024/go.mod h1:fYVpevZiA79ef8Q1DkUgg/MF53oy4mKFSFTnK+EeiO0=

--- a/hugo.toml
+++ b/hugo.toml
@@ -3,7 +3,10 @@ RelativeURLs=true
 CanonifyURLs=true
 languageCode = 'en-us'
 title = 'Zhong Zhang'
-theme = 'poison-modified'
+
+[module]
+  [[module.imports]]
+    path = 'github.com/lukeorth/poison'
 
 paginate = 10
 pluralizelisttitles = false   # removes the automatically appended "s" on sidebar entries

--- a/layouts/_shortcodes/first5sections.html
+++ b/layouts/_shortcodes/first5sections.html
@@ -1,0 +1,13 @@
+{{ $src := .Page.Site.GetPage (.Get "page") }}
+
+{{ if $src }}
+  {{/* Split content into sections by H3 headings */}}
+  {{ $parts := split $src.RawContent "\n### " }}
+
+  {{/* Skip index 0 if it’s pre-heading content */}}
+  {{ range first (.Get "n") (after 1 $parts) }}
+	{{ printf "### %s" . | markdownify }}
+  {{ end }}
+{{ else }}
+  <p><em>Page not found: {{ .page }}</em></p>
+{{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,0 +1,22 @@
+<meta http-equiv = "refresh" content = "0; url =/about/" />
+{{ define "main" -}}
+<div class="posts">
+    {{ $frontPageTypes := default (slice "posts") .Site.Params.front_page_content }}
+    {{ range (.Paginate (where .Site.RegularPages "Type" "in" $frontPageTypes)).Pages }}
+    <article class="post">
+        {{ partial "post/info.html" . }}
+        {{ if or (.Site.Params.noSummary) (.Params.noSummary) }}
+        {{ .Content }}
+        {{ else }}
+        {{ .Summary }}
+        {{ if .Truncated }}
+        <div class="read-more-link">
+            <a href="{{ .RelPermalink }}">Read More…</a>
+        </div>
+        {{ end }}
+        {{ end }}
+    </article>
+    {{- end }}
+</div>
+{{ partial "pagination.html" . }}
+{{- end }}


### PR DESCRIPTION
This switches to hugo modules, since that's the modern way to do themes with hugo, and means if we get a deprecation error we can just call "hugo mod get -u" to update the theme.

Papers and such have also been added, as well as a display of your 5 most recent papers (or however many there are) to your about landing about page.